### PR TITLE
Add node_required validation to config-loader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,12 @@ tofu apply     # Apply changes
 tofu destroy   # Tear down (use with caution)
 tofu fmt       # Format HCL files
 
+# Deploy to a specific node (required - envs are node-agnostic templates)
+tofu apply -var="node=pve"
+tofu apply -var="node=father"
+
 # With custom site-config path (development)
-tofu plan -var="site_config_path=/path/to/site-config"
+tofu plan -var="node=pve" -var="site_config_path=/path/to/site-config"
 ```
 
 ## Project Structure
@@ -54,10 +58,10 @@ Configuration is loaded from site-config YAML files via the `config-loader` modu
 site-config/
 ├── site.yaml           # Site-wide defaults (timezone, domain, datastore)
 ├── secrets.yaml        # All sensitive values (SOPS encrypted)
-├── nodes/              # PVE instance configuration
+├── nodes/              # PVE instance configuration (primary key from filename)
 │   └── {node}.yaml     # API endpoint, token ref, datastore
-└── envs/               # Environment configuration
-    └── {env}.yaml      # Node reference, env-specific settings
+└── envs/               # Deployment topology templates (node-agnostic)
+    └── {env}.yaml      # env-specific settings, node at deploy time
 ```
 
 ### Config-Loader Module
@@ -70,8 +74,8 @@ module "config" {
   source = "../../modules/config-loader"
 
   site_config_path = var.site_config_path  # Default: /opt/homestak/site-config
-  env              = "dev"                  # Environment name
-  node             = var.node               # Optional node override
+  env              = "dev"                  # Environment name (from filename)
+  node             = var.node               # Target PVE node (required)
 }
 
 # Use outputs in providers and resources
@@ -241,7 +245,7 @@ Internet
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `site_config_path` | /opt/homestak/site-config | Path to site-config directory |
-| `node` | (from env.yaml) | Optional node override |
+| `node` | (required) | Target PVE node - envs are node-agnostic templates |
 
 ## Prerequisites
 

--- a/modules/config-loader/variables.tf
+++ b/modules/config-loader/variables.tf
@@ -13,7 +13,7 @@ variable "env" {
 }
 
 variable "node" {
-  description = "Optional node override (defaults to env's node reference)"
+  description = "Target PVE node. Required when env is node-agnostic (no node: field). Overrides env's node reference if both provided."
   type        = string
   default     = null
 }


### PR DESCRIPTION
## Summary

- Support node-agnostic env files (`node:` removed from envs/*.yaml)
- Add `check` block to validate node is specified at deploy time
- Update variable description for node requirement
- Update CLAUDE.md with node-agnostic deployment examples

## Changes

### config-loader/main.tf
- Use `try()` to handle missing `node:` field in env files
- Add `check "node_required"` block for clear error message

### config-loader/variables.tf
- Update `node` variable description to indicate it's required for node-agnostic envs

## Deploy Pattern

```bash
# Node is now required (envs are node-agnostic templates)
tofu apply -var="node=pve"    # Deploy to pve
tofu apply -var="node=father" # Deploy same env to father

# Error if node not specified
tofu apply  # Fails with clear error message
```

## Test plan

- [x] `tofu validate -var="node=pve"` passes
- [x] `tofu plan -var="node=pve"` generates valid plan
- [x] Missing node fails with clear error message
- [ ] E2E test after merge with site-config changes

Relates to: homestak-dev/site-config#8

🤖 Generated with [Claude Code](https://claude.com/claude-code)