### PR TITLE
Fix CLAUDE.md: add missing gateway field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ variable "vms" {
     disk     = number
     bridge   = optional(string, "vmbr0")
     ip       = optional(string, "dhcp")
+    gateway  = optional(string)
     packages = optional(list(string), [])
   }))
 }


### PR DESCRIPTION
## Summary

Fix discrepancy found during CLAUDE.md accuracy check.

## Changes

- Add missing `gateway = optional(string)` field to vms variable documentation

The gateway field is used for static IP configuration but was missing from the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)