### PR TITLE
Add CI workflow for OpenTofu validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: 1.9.0
+
+      - name: Check formatting
+        run: tofu fmt -check -recursive
+
+      - name: Validate modules
+        run: |
+          for module in proxmox-vm proxmox-file proxmox-sdn; do
+            echo "Validating $module..."
+            cd $module
+            tofu init -backend=false
+            tofu validate
+            cd ..
+          done
+
+      - name: Validate environments
+        run: |
+          for env in envs/generic; do
+            echo "Validating $env..."
+            cd $env
+            tofu init -backend=false
+            tofu validate
+            cd ../..
+          done


### PR DESCRIPTION
## Summary
Adds GitHub Actions CI workflow for OpenTofu code validation.

**Checks included:**
- `tofu fmt -check` (formatting consistency)
- `tofu init && tofu validate` for all modules
- `tofu init && tofu validate` for generic environment

Part of .github#10 CI/CD Phase 1.

## Checklist
- [x] Workflow validates successfully
- [ ] CLAUDE.md updated (if architecture/workflow changed)