### PR TITLE
Fix CI by creating dummy SSH key for validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           tofu_version: 1.9.0
 
+      - name: Create dummy SSH key for validation
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keygen -t rsa -f ~/.ssh/id_rsa -N "" -q
+
       - name: Check formatting
         run: tofu fmt -check -recursive
 


### PR DESCRIPTION
## Problem

CI fails with:
```
Error: Invalid function argument
  on providers.tf line 16, in provider "proxmox":
  16:     private_key = file("~/.ssh/id_rsa")

Invalid value for "path" parameter: no file exists at "~/.ssh/id_rsa"
```

## Root Cause

The `file()` function is evaluated at validate time, not apply time. GitHub Actions runners don't have SSH keys at `~/.ssh/id_rsa`.

## Fix

Create a dummy SSH key before running validation. The key is never used for actual connections - it just satisfies the `file()` call during validation.

## Testing

CI should pass after this change.