### PR TITLE
fix(generic): Add ssh_host variable for remote file uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Add ssh_host variable and node block to generic environment provider
+  - Enables remote SSH connections for file uploads on non-localhost nodes
+  - Required for recursive-pve scenarios running tofu on inner PVE
+
 ## v0.26 - 2026-01-17
 
 - Release alignment with homestak v0.26

--- a/envs/generic/providers.tf
+++ b/envs/generic/providers.tf
@@ -15,6 +15,10 @@ provider "proxmox" {
     agent       = false
     private_key = file("~/.ssh/id_rsa")
     username    = var.ssh_user
+    node {
+      name    = var.node
+      address = var.ssh_host
+    }
   }
   random_vm_ids = true
   tmp_dir       = "/var/tmp"

--- a/envs/generic/variables.tf
+++ b/envs/generic/variables.tf
@@ -23,6 +23,12 @@ variable "ssh_user" {
   default     = "root"
 }
 
+variable "ssh_host" {
+  description = "SSH host for file uploads (defaults to localhost)"
+  type        = string
+  default     = "127.0.0.1"
+}
+
 variable "datastore" {
   description = "Default datastore for VMs"
   type        = string


### PR DESCRIPTION
## Summary

Enable remote SSH connections for file uploads on non-localhost nodes.

## Type of Change
- [x] Bug fix

## Changes

- Add `ssh_host` variable (defaults to `127.0.0.1`)
- Add `node` block to proxmox provider configuration
- Enables file uploads via SSH when running tofu on remote hosts

## Testing

Validated via iac-driver recursive-pve-roundtrip scenario.

## PR Readiness Checklist

- [x] Feature tested end-to-end
- [x] CHANGELOG entry in this PR