### PR TITLE
feat: Add automation_user for non-root SSH access

### DIFF
--- a/envs/generic/main.tf
+++ b/envs/generic/main.tf
@@ -16,11 +16,15 @@ locals {
     hostname: ${name}
 
     users:
+      - name: ${var.automation_user}
+        groups: sudo
+        shell: /bin/bash
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        ssh_authorized_keys:
+          ${indent(6, join("\n", formatlist("- \"%s\"", var.ssh_keys)))}
       - name: root
         lock_passwd: false
         hashed_passwd: ${var.root_password}
-        ssh_authorized_keys:
-          ${indent(6, join("\n", formatlist("- \"%s\"", var.ssh_keys)))}
 
     package_update: ${length(vm.packages) > 0 ? "true" : "false"}
     packages:

--- a/envs/generic/variables.tf
+++ b/envs/generic/variables.tf
@@ -18,9 +18,15 @@ variable "api_token" {
 }
 
 variable "ssh_user" {
-  description = "SSH user for provisioning"
+  description = "SSH user for provider connection to PVE host"
   type        = string
   default     = "root"
+}
+
+variable "automation_user" {
+  description = "User created in VMs via cloud-init (with sudo)"
+  type        = string
+  default     = "homestak"
 }
 
 variable "ssh_host" {


### PR DESCRIPTION
## Summary

Adds `automation_user` variable for cloud-init to create a non-root user with sudo access. SSH keys are now authorized for this user instead of root, avoiding PVE's root key management issues.

## Type of Change
- [x] New feature

## Changes
- Add `automation_user` variable (default: `homestak`)
- Move SSH key authorization from root to automation_user
- Update `ssh_user` description to clarify it's for PVE host connection

## Testing
- `recursive-pve-roundtrip --manifest n3-full` passes
- SSH access works via automation_user at all nesting levels

## Related Issues
Part of homestak-dev/iac-driver#133

## Checklist
- [x] Tests pass locally
- [x] Integration test scenario identified and passes
- [x] External tool assumptions verified

---

🤖 Generated with [Claude Code](https://claude.ai/code)