### PR TITLE
Sprint 174: v0.45 Injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+- Add `spec_server` variable for Create → Specify flow (#174)
+  - Injects `HOMESTAK_SPEC_SERVER`, `HOMESTAK_IDENTITY`, `HOMESTAK_AUTH_TOKEN` via cloud-init
+  - Writes environment variables to `/etc/profile.d/homestak.sh`
+  - Auto-fetches spec on first boot (idempotent)
+- Add `auth_token` field to `vms` object for posture-based authentication
+
 ## v0.44 - 2026-02-02
 
 - Release alignment with homestak v0.44

--- a/envs/generic/variables.tf
+++ b/envs/generic/variables.tf
@@ -56,16 +56,17 @@ variable "ssh_keys" {
 variable "vms" {
   description = "List of VMs to create (resolved by iac-driver)"
   type = list(object({
-    name     = string
-    vmid     = optional(number)
-    image    = string
-    cores    = number
-    memory   = number
-    disk     = number
-    bridge   = optional(string, "vmbr0")
-    ip       = optional(string, "dhcp")
-    gateway  = optional(string)
-    packages = optional(list(string), [])
+    name       = string
+    vmid       = optional(number)
+    image      = string
+    cores      = number
+    memory     = number
+    disk       = number
+    bridge     = optional(string, "vmbr0")
+    ip         = optional(string, "dhcp")
+    gateway    = optional(string)
+    packages   = optional(list(string), [])
+    auth_token = optional(string, "")
   }))
 
   validation {
@@ -87,6 +88,13 @@ variable "vms" {
     condition     = alltrue([for vm in var.vms : can(regex("^[a-z][a-z0-9-]*$", vm.name))])
     error_message = "VM names must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens."
   }
+}
+
+# Spec server URL for Create → Specify flow (v0.45+)
+variable "spec_server" {
+  description = "Spec server URL for automatic spec discovery"
+  type        = string
+  default     = ""
 }
 
 # Image name to Proxmox file ID mapping


### PR DESCRIPTION
## Summary

Add spec server and auth token injection to cloud-init for the Create → Specify flow. VMs can now automatically discover and fetch their specifications on first boot.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] Sprint merge

## Changes
- Add `spec_server` variable for spec discovery URL
- Add `auth_token` field to `vms` object for posture-based authentication
- Inject `HOMESTAK_SPEC_SERVER`, `HOMESTAK_IDENTITY`, `HOMESTAK_AUTH_TOKEN` via cloud-init write_files
- Auto-fetch spec on first boot with idempotency check
- Update CLAUDE.md with Create → Specify flow documentation

## Sprint Scope
- Cloud-init spec server integration (Sprint 3 of v0.45 release)

## Validation Evidence
- **Scenario:** `vm-roundtrip`
- **Host:** father
- **Result:** PASSED (20.0s)
- **Backward compatible:** No injection when `spec_server` is empty

## Testing
- tofu fmt: passing
- tofu validate: passing
- Integration scenario: vm-roundtrip on father (PASSED)

## Related Issues
Part of #154 (v0.45 Release Planning)

## Sprint Issue
Closes homestak-dev/homestak-dev#174

## Checklist
- [x] Feature tested end-to-end (vm-roundtrip scenario)
- [x] External tool assumptions verified (cloud-init write_files/runcmd)
- [x] CHANGELOG entry in this PR
- [x] CLAUDE.md updated with Create → Specify flow
- [x] Prerequisites documented (spec_server in site.yaml)
- [x] Integration test scenario identified (vm-roundtrip)

---
🤖 Generated with [Claude Code](https://claude.ai/code)